### PR TITLE
feat: async support for serial and delay traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp2003a"
-version = "0.0.22"
+version = "0.0.23"
 description = "MCP2003A LIN transceiver driver with embedded-hal traits for no-std environments."
 edition = "2021"
 license = "MIT"
@@ -13,3 +13,5 @@ keywords = ["lin", "linbus", "mcp2003a", "automotive", "no-std"]
 [dependencies]
 embedded-hal = "1.0.0"
 embedded-hal-nb = "1.0.0"
+embedded-hal-async = "1.0.0"
+embedded-io-async = "0.6.1"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ mcp2003a.init(lin_bus_config);
 
 mcp2003a.send_wakeup();
 
-mc2003a.send_frame(0x01, &[0x02, 0x03], 0x05).unwrap();
+// Works for different LIN versions, you calculate id and checksum based on your application
+mcp2003a.send_frame(0x01, &[0x02, 0x03], 0x05).unwrap();
 
 let mut read_buffer = [0u8; 8]; // Initialize the buffer to the frame's known size
 let checksum = mcp2003a.read_frame(0xC1, &mut read_buffer).unwrap();


### PR DESCRIPTION
Using the async traits by the same team who provides our original ones.

```
embedded-hal-async = "1.0.0"
embedded-io-async = "0.6.1"
```

- send_break_async - delay
- send_wakeup_async - delay
- send_frame_async - delay, serial
- read_frame_async - delay, serial